### PR TITLE
Fix/disclaimer image

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "URIjs": "uri.js#~1.14.0",
-    "ckeditor": "^4.7.2",
+    "ckeditor": "^4.9.1",
     "ng-ckeditor": "^0.2.1",
     "punycode": "~1.2.4",
     "jsurl": "https://github.com/Sage/jsurl.git#~0.1.4"

--- a/src/exchange/exchange.html
+++ b/src/exchange/exchange.html
@@ -171,7 +171,7 @@
 
     <exchange-wizard-hosted-creation data-ng-if="ctrl.shouldOpenWizard && ctrl.hasNoDomain"></exchange-wizard-hosted-creation>
 
-    <div class="modal fade currentAction" id="currentAction" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal fade currentAction" id="currentAction" role="dialog" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content" id="modal-container" data-ng-include="ctrl.services.navigation.stepPath"></div>
             <div class="help4wizards" id="modal-help"></div>


### PR DESCRIPTION
## Fix focus on ckeditor modals when adding/editing a disclaimer


### Description of the Change

Before: It was not possible to input in CKEditor opened modal windows (e.g : to add an image)
Now: All CKEditor modals get focus when triggered 
