### PR TITLE
fix: modal backdrop fix on delete

### DIFF
--- a/src/exchange/services/exchange.navigation.service.js
+++ b/src/exchange/services/exchange.navigation.service.js
@@ -14,6 +14,7 @@ angular
 
         resetAction () {
             $("#currentAction").modal("hide");
+            $(".modal-backdrop").remove();
 
             this.currentActionData = null;
             this.stepPath = "";


### PR DESCRIPTION
## Manager stuck on delete of exchange account


### Description of the Change

Remove backdrop on close of modal

### Benefits

Closes modal properly

### Possible Drawbacks

None

### Applicable Issues

MANAGER-796
