### PR TITLE
fix(renew): fix automatic opening of renew modal

### DIFF
--- a/src/exchange/exchange.controller.js
+++ b/src/exchange/exchange.controller.js
@@ -65,21 +65,21 @@ angular.module('Module.exchange.controllers').controller(
         this.hasNoDomain = false;
       });
 
-      if ($location.search().action === 'billing') {
-        $timeout(() => {
-          $rootScope.$broadcast(
-            'leftNavigation.selectProduct.fromName',
-            this.parseLocationForExchangeData(),
-          );
-          $scope.setAction(
-            'exchange/header/update-renew/update-renew',
-            this.parseLocationForExchangeData(),
-          );
-          this.retrievingExchange();
-        }, 2000);
-      } else {
-        this.retrievingExchange();
-      }
+      this.retrievingExchange()
+        .then(() => {
+          if ($location.search().action === 'billing') {
+            $timeout(() => {
+              $rootScope.$broadcast(
+                'leftNavigation.selectProduct.fromName',
+                this.parseLocationForExchangeData(),
+              );
+              $scope.setAction(
+                'exchange/header/update-renew/update-renew',
+                this.parseLocationForExchangeData(),
+              );
+            });
+          }
+        });
     }
 
     $onInit() {


### PR DESCRIPTION
##  Fix automatic renew modal opening

### Description of the Change

Modal is supposed to open when `action=billing` param is given (e.g : redirect from billing section)

MANAGER-1899