### PR TITLE
fix(renew): add delay before opening modal

### DIFF
--- a/src/exchange/exchange.controller.js
+++ b/src/exchange/exchange.controller.js
@@ -87,7 +87,7 @@ angular.module('Module.exchange.controllers').controller(
                 modals[urlParamAction],
                 this.parseLocationForExchangeData(),
               );
-            });
+            }, 2000);
           }
         });
     }


### PR DESCRIPTION
## Add delay before opening modal

When automatic modal opening is required from another section (e.g: billing) modal doesn't open as DOM is not yet completely initialized

ref: MBP-205

