### PR TITLE
Fix/modal opening

### DIFF
--- a/src/exchange/exchange.controller.js
+++ b/src/exchange/exchange.controller.js
@@ -51,10 +51,6 @@ angular.module('Module.exchange.controllers').controller(
         this.retrievingExchange();
       });
 
-      $scope.$on('$locationChangeStart', () => {
-        this.services.navigation.resetAction();
-      });
-
       $scope.$on('exchange.wizard_hosted_creation.display', () => {
         this.shouldOpenWizard = this.services.exchangeServiceInfrastructure.isHosted();
         this.hasNoDomain = true;


### PR DESCRIPTION
## Fix actions automatic modal opening


### Description of the Change

By default when changing location modals are automatically close.
Prevent modal from closing on location change. Indeed when a modal is open it is not possible to change location and url change cause page reload

MBP-205
