### PR TITLE
fix(exchange): prevent infinite api calls on search

### DIFF
--- a/src/exchange/external-contact/external-contact.controller.js
+++ b/src/exchange/external-contact/external-contact.controller.js
@@ -25,8 +25,6 @@ angular.module('Module.exchange.controllers').controller(
       this.contacts = null;
       this.filter = null;
 
-      this.debouncedRetrieveAccounts = _.debounce(this.loadContacts, 300);
-
       $scope.$on(Exchange.events.externalcontactsChanged, () => $scope.$broadcast('paginationServerSide.reload', 'externalContactsTable'));
 
       $scope.getContacts = () => this.contacts;
@@ -35,7 +33,7 @@ angular.module('Module.exchange.controllers').controller(
     }
 
     onSearchValueChange() {
-      this.debouncedRetrieveAccounts();
+      this.loadContacts();
     }
 
     loadContacts(count, offset) {

--- a/src/exchange/shared/shared.controller.js
+++ b/src/exchange/shared/shared.controller.js
@@ -34,8 +34,6 @@ angular.module('Module.exchange.controllers').controller(
 
       $scope.$on(Exchange.events.publicFoldersChanged, () => $scope.$broadcast('paginationServerSide.reload', 'publicFoldersTable'));
 
-      this.debouncedRetrievingMailingLists = _.debounce(this.retrievingMailingLists, 300);
-
       $scope.retrievingMailingLists = (count, offset) => this.retrievingMailingLists(count, offset);
       $scope.getPublicFoldersList = () => this.publicFoldersList;
       $scope.getLoading = () => this.loading;
@@ -43,7 +41,7 @@ angular.module('Module.exchange.controllers').controller(
     }
 
     onSearch() {
-      this.debouncedRetrievingMailingLists();
+      this.retrievingMailingLists();
     }
 
     retrievingMailingLists(count, offset) {


### PR DESCRIPTION
# Prevent infinite API calls on search

## :ambulance: Hotfix

7a08c37 - fix(exchange): prevent infinite api calls on search

## :link: Related

- ovh-ux/manager#1421

## :house: Internal

ref: DTRUN-3748

cc @lizardK 
